### PR TITLE
Fix HTTP 500 errors when date invalid or not plausible 

### DIFF
--- a/app/controllers/workloads_controller.rb
+++ b/app/controllers/workloads_controller.rb
@@ -32,6 +32,12 @@ class WorkloadsController < ApplicationController
     # Make sure that last_day is at most 12 months after first_day to prevent
     # long running times
     @last_day = [(@first_day >> 12) - 1, @last_day].min
+
+    # Make sure that today is not after last_day to prevent a crash in the
+    # workload calculation (today would be outside the time span)
+    @today_capped = @today > @last_day
+    @today = [@today, @last_day].min
+
     @time_span_to_display = @first_day..@last_day
 
     if @date_check
@@ -56,6 +62,7 @@ class WorkloadsController < ApplicationController
     respond_to do |format|
       format.html do
         flash.now[:error] = l(:error_date_setting) unless @date_check
+        flash.now[:warning] = l(:warning_today_capped_to_last_day) if @today_capped
         render action: :index
       end
 

--- a/app/controllers/workloads_controller.rb
+++ b/app/controllers/workloads_controller.rb
@@ -110,10 +110,10 @@ class WorkloadsController < ApplicationController
   end
 
   def sanitizeDateParameter(parameter, default)
-    if parameter.respond_to?(:to_date)
-      parameter.to_date
-    else
-      default
-    end
+    return default unless parameter.respond_to?(:to_date)
+
+    parameter.to_date
+  rescue Date::Error
+    default
   end
 end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -100,6 +100,7 @@ de:
   workload_unscheduled_issues_num: 'Anzahl ungeplanter Tickets:'
   workload_unscheduled_issues_hours: 'Stunden aus ungeplanten Tickets:'
   error_date_setting: 'Überprüfen Sie Ihre Eingabe! Das Enddatum (bis) liegt vor dem Startdatum (von).'
+  warning_today_capped_to_last_day: 'Das "Als Heute verwenden"-Datum lag nach dem Enddatum und wurde auf das Enddatum gesetzt.'
   error_encoding_setting: 'Zeichenkodierung nicht erlaubt. Gültige Werte: %{value}.'
   label_workload_calculation: Workloadberechnung
   label_include_parent_tasks: Hauptaufgaben einbeziehen

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,6 +100,7 @@ en:
   workload_unscheduled_issues_num: 'Number of unscheduled issues:'
   workload_unscheduled_issues_hours: 'Hours of unscheduled issues:'
   error_date_setting: 'Please check your data! The end date is before the start date.'
+  warning_today_capped_to_last_day: 'The "Use as today" date was after the end date and has been set to the end date.'
   error_encoding_setting: 'Character encoding not allowed. Valid values: %{value}.'
   label_workload_calculation: Workload calculation
   label_include_parent_tasks: Include parent tasks

--- a/test/functional/workloads_controller_test.rb
+++ b/test/functional/workloads_controller_test.rb
@@ -43,5 +43,32 @@ module RedmineWorkload
 
       assert flash[:error].match(/Character encoding not allowed./)
     end
+
+    test 'should get index with invalid first_day date without raising an error' do
+      manager = roles :roles_001
+      manager.add_permission! :view_all_workloads
+      log_user('jsmith', 'jsmith')
+
+      get workloads_path(workload: { first_day: '2026-01-32' })
+      assert_response :success
+    end
+
+    test 'should get index with invalid last_day date without raising an error' do
+      manager = roles :roles_001
+      manager.add_permission! :view_all_workloads
+      log_user('jsmith', 'jsmith')
+
+      get workloads_path(workload: { last_day: '2026-13-01' })
+      assert_response :success
+    end
+
+    test 'should get index with invalid start_date without raising an error' do
+      manager = roles :roles_001
+      manager.add_permission! :view_all_workloads
+      log_user('jsmith', 'jsmith')
+
+      get workloads_path(workload: { start_date: 'not-a-date' })
+      assert_response :success
+    end
   end
 end

--- a/test/functional/workloads_controller_test.rb
+++ b/test/functional/workloads_controller_test.rb
@@ -70,5 +70,31 @@ module RedmineWorkload
       get workloads_path(workload: { start_date: 'not-a-date' })
       assert_response :success
     end
+
+    test 'should get index without error when start_date is after last_day' do
+      manager = roles :roles_001
+      manager.add_permission! :view_all_workloads
+      log_user('jsmith', 'jsmith')
+
+      get workloads_path(workload: {
+                           first_day: '2026-01-01',
+                           last_day: '2026-01-31',
+                           start_date: '2026-06-01'
+                         })
+      assert_response :success
+    end
+
+    test 'should show warning when start_date is after last_day' do
+      manager = roles :roles_001
+      manager.add_permission! :view_all_workloads
+      log_user('jsmith', 'jsmith')
+
+      get workloads_path(workload: {
+                           first_day: '2026-01-01',
+                           last_day: '2026-01-31',
+                           start_date: '2026-06-01'
+                         })
+      assert flash[:warning].present?
+    end
   end
 end


### PR DESCRIPTION
Wrap the `to_date` conversion in `sanitizeDateParameter` with a
begin-rescue block to catch `Date::Error`. Previously, strings like
"2026-01-32" passed the `respond_to?(:to_date)` check but raised an
unhandled exception during conversion. Now invalid dates fall back to
the default value instead of crashing.
Adds functional tests for all three date parameters (first_day,
last_day, start_date) to cover the invalid date case.

Fixes #41

---

When the user sets a 'Use as today' (start_date) value beyond the last_day of the displayed time span, the UserWorkload model crashes with a NoMethodError because 'today' falls outside the time_span and hours_for_issue[today] returns nil.
Cap @today to @last_day in the controller before passing it to UserWorkload. Show a flash warning when the capping occurs so the user is informed.

Fixes #40